### PR TITLE
Add notice.

### DIFF
--- a/legal/libgdx/NOTICE.txt
+++ b/legal/libgdx/NOTICE.txt
@@ -1,0 +1,10 @@
+# This is the official list of the AUTHORS of libgdx
+# for copyright purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
+
+# Names should be added to this file as
+#	Name or Organization <email address>
+# The email address is not required for organizations.
+Mario Zechner <badlogicgames@gmail.com>
+Nathan Sweet <nathan.sweet@gmail.com> 


### PR DESCRIPTION
As playn now ships with [code from libgdx](https://github.com/threerings/playn/blob/master/java/src/playn/java/JavaGL20.java), the [notice file](https://libgdx.googlecode.com/svn/trunk/gdx/NOTICE) should be included.
