### PR TITLE
Bugfix for async on android < JB.

### DIFF
--- a/android/src/playn/android/AndroidPlatform.java
+++ b/android/src/playn/android/AndroidPlatform.java
@@ -72,16 +72,22 @@ public class AndroidPlatform extends AbstractPlatform {
 
   @Override
   public void invokeAsync(final Runnable action) {
-    new AsyncTask<Void,Void,Void>() {
-      public Void doInBackground(Void... params) {
-        try {
-          action.run();
-        } catch (Exception e) {
-          log.warn("Async task failure [task=" + action + "]", e);
-        }
-        return null;
+    activity.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        new AsyncTask<Void, Void, Void>() {
+          public Void doInBackground(Void... params) {
+            try {
+              action.run();
+            } catch (Exception e) {
+              log.warn("Async task failure [task=" + action + "]", e);
+            }
+            return null;
+          }
+
+        }.execute();
       }
-    }.execute();
+    });
   }
 
   @Override


### PR DESCRIPTION
Crashes on 2.3.7. "The AsyncTask class must be loaded on the UI thread. This is done automatically as of JELLY_BEAN." -- http://developer.android.com/reference/android/os/AsyncTask.html
