### PR TITLE
Use the module base as the default path prefix for HtmlAssets.

### DIFF
--- a/html/src/playn/html/HtmlAssets.java
+++ b/html/src/playn/html/HtmlAssets.java
@@ -54,7 +54,7 @@ public class HtmlAssets extends AbstractAssets<Void> {
   private final HtmlPlatform platform;
   private final Map<String, AutoClientBundleWithLookup> clientBundles =
     new HashMap<String, AutoClientBundleWithLookup>();
-  private String pathPrefix = "";
+  private String pathPrefix = GWT.getModuleBaseForStaticFiles();
   private Scale assetScale = null;
   private ImageManifest imageManifest;
 


### PR DESCRIPTION
Let HtmlAssets load resources as same as what the normal GWT based app does. In so doing, we don't need to set the path prefix in every module.
