### PR TITLE
Use standard webgl context in the first place.

### DIFF
--- a/webgl/src/com/google/gwt/webgl/client/WebGLRenderingContext.java
+++ b/webgl/src/com/google/gwt/webgl/client/WebGLRenderingContext.java
@@ -471,7 +471,7 @@ public class WebGLRenderingContext extends JavaScriptObject {
    * context is available.
    */
   public static native WebGLRenderingContext getContext(CanvasElement canvas, WebGLContextAttributes attributes) /*-{
-    var names = ["experimental-webgl", "webgl", "moz-webgl", "webkit-webgl", "webkit-3d"];
+    var names = ["webgl", "experimental-webgl", "moz-webgl", "webkit-webgl", "webkit-3d"];
     for (var i = 0; i < names.length; i++) {
       try {
         var ctx = canvas.getContext(names[i], attributes);


### PR DESCRIPTION
This patch fixes error in Firefox:
"Error: WebGL: Retrieving a WebGL context from a canvas via a request id ('webgl') different from the id used to create the context ('experimental-webgl') is not allowed."
