### PR TITLE
Configure the websocket RFC draft version

### DIFF
--- a/android/src/playn/android/AndroidNet.java
+++ b/android/src/playn/android/AndroidNet.java
@@ -40,15 +40,17 @@ import playn.core.util.Callback;
 
 class AndroidNet extends NetImpl {
 
-  AndroidNet(AndroidPlatform platform) {
+  final private int draft;
+  AndroidNet(AndroidPlatform platform, int draft) {
     super(platform);
+    this.draft = draft;
   }
 
   @Override
   public WebSocket createWebSocket(String url, WebSocket.Listener listener) {
-    return new AndroidWebSocket(platform, url, listener);
+    return new AndroidWebSocket(platform, url, listener, draft);
   }
-
+  
   @Override
   protected void execute(final BuilderImpl req, final Callback<Response> callback) {
     platform.invokeAsync(new Runnable() {

--- a/android/src/playn/android/AndroidPlatform.java
+++ b/android/src/playn/android/AndroidPlatform.java
@@ -48,7 +48,11 @@ public class AndroidPlatform extends AbstractPlatform {
   private final Json json;
   private final long start = System.nanoTime();
 
-  protected AndroidPlatform(GameActivity activity, AndroidGL20 gl20) {
+  protected AndroidPlatform(GameActivity activity, AndroidGL20 gl20){
+    this(activity, gl20, 10);
+  }
+  
+  protected AndroidPlatform(GameActivity activity, AndroidGL20 gl20, int wsDraft) {
     super(new AndroidLog(activity));
     this.activity = activity;
 
@@ -57,7 +61,7 @@ public class AndroidPlatform extends AbstractPlatform {
     assets = new AndroidAssets(this);
     json = new JsonImpl();
     keyboard = new AndroidKeyboard(this);
-    net = new AndroidNet(this);
+    net = new AndroidNet(this, wsDraft);
     pointer = new AndroidPointer();
     storage = new AndroidStorage(this);
     touch = new TouchImpl();

--- a/android/src/playn/android/AndroidWebSocket.java
+++ b/android/src/playn/android/AndroidWebSocket.java
@@ -20,6 +20,11 @@ import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 
 import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.drafts.Draft_10;
+import org.java_websocket.drafts.Draft_17;
+import org.java_websocket.drafts.Draft_75;
+import org.java_websocket.drafts.Draft_76;
 import org.java_websocket.handshake.ServerHandshake;
 
 import playn.core.Net;
@@ -29,7 +34,7 @@ public class AndroidWebSocket implements Net.WebSocket {
 
   private final WebSocketClient socket;
 
-  public AndroidWebSocket(final Platform platform, String uri, final Listener listener) {
+  public AndroidWebSocket(final Platform platform, String uri, final Listener listener, int draft) {
     URI juri = null;
     try {
       juri = new URI(uri);
@@ -37,7 +42,7 @@ public class AndroidWebSocket implements Net.WebSocket {
       throw new RuntimeException(e);
     }
 
-    socket = new WebSocketClient(juri) {
+    socket = new WebSocketClient(juri, useDraft(draft)) {
       @Override
       public void onMessage(final ByteBuffer buffer) {
         platform.invokeLater(new Runnable() {
@@ -84,6 +89,18 @@ public class AndroidWebSocket implements Net.WebSocket {
       }
     };
     socket.connect();
+  }
+  
+  private Draft useDraft(int draft){
+    switch (draft) {
+      case 17:
+        return new Draft_17();
+      case 75:
+        return new Draft_75();
+      case 76:
+        return new Draft_76();
+    }
+    return new Draft_10();
   }
 
   @Override

--- a/java/src/playn/java/JavaNet.java
+++ b/java/src/playn/java/JavaNet.java
@@ -28,13 +28,16 @@ import playn.core.util.Callback;
 
 public class JavaNet extends NetImpl {
 
-  public JavaNet(JavaPlatform platform) {
+  final private int draft;
+  
+  public JavaNet(JavaPlatform platform, int draft) {
     super(platform);
+    this.draft = draft;
   }
 
   @Override
   public WebSocket createWebSocket(String url, WebSocket.Listener listener) {
-    return new JavaWebSocket(platform, url, listener);
+    return new JavaWebSocket(platform, url, listener, draft);
   }
 
   @Override

--- a/java/src/playn/java/JavaPlatform.java
+++ b/java/src/playn/java/JavaPlatform.java
@@ -86,6 +86,9 @@ public class JavaPlatform extends AbstractPlatform {
 
     /** Stop processing frames while the app is "inactive", to better emulate iOS. */
     public boolean truePause;
+    
+    /** Configure the web socket RFC draft number: 10, 17, 75 or 76 */
+    public int wsDraft = 10;
   }
 
   /**
@@ -129,7 +132,7 @@ public class JavaPlatform extends AbstractPlatform {
 
   private final Config config;
   private final JavaAudio audio = new JavaAudio(this);
-  private final JavaNet net = new JavaNet(this);
+  private final JavaNet net;
   private final JavaStorage storage;
   private final JsonImpl json = new JsonImpl();
   private final JavaKeyboard keyboard;
@@ -159,6 +162,7 @@ public class JavaPlatform extends AbstractPlatform {
     } else {
       mouse = createMouse();
     }
+    net = new JavaNet(this, config.wsDraft);
 
     if (touch instanceof JavaEmulatedTouch || config.activationKey != null) {
       final Key pivotKey = (touch instanceof JavaEmulatedTouch) ? config.pivotKey : null;

--- a/java/src/playn/java/JavaWebSocket.java
+++ b/java/src/playn/java/JavaWebSocket.java
@@ -20,6 +20,11 @@ import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 
 import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.drafts.Draft_10;
+import org.java_websocket.drafts.Draft_17;
+import org.java_websocket.drafts.Draft_75;
+import org.java_websocket.drafts.Draft_76;
 import org.java_websocket.handshake.ServerHandshake;
 
 import playn.core.Net;
@@ -29,7 +34,7 @@ public class JavaWebSocket implements Net.WebSocket {
 
   private final WebSocketClient socket;
 
-  public JavaWebSocket(final Platform platform, String uri, final Listener listener) {
+  public JavaWebSocket(final Platform platform, String uri, final Listener listener, int draft) {
     URI juri = null;
     try {
       juri = new URI(uri);
@@ -37,7 +42,7 @@ public class JavaWebSocket implements Net.WebSocket {
       throw new RuntimeException(e);
     }
 
-    socket = new WebSocketClient(juri) {
+    socket = new WebSocketClient(juri, useDraft(draft)) {
       @Override
       public void onMessage(final ByteBuffer buffer) {
         platform.invokeLater(new Runnable() {
@@ -84,6 +89,18 @@ public class JavaWebSocket implements Net.WebSocket {
       }
     };
     socket.connect();
+  }
+  
+  private Draft useDraft(int draft){
+    switch (draft) {
+      case 17:
+        return new Draft_17();
+      case 75:
+        return new Draft_75();
+      case 76:
+        return new Draft_76();
+    }
+    return new Draft_10();
   }
 
   @Override

--- a/robovm/src/playn/robovm/RoboNet.java
+++ b/robovm/src/playn/robovm/RoboNet.java
@@ -41,7 +41,7 @@ public class RoboNet extends NetImpl {
 
   @Override
   public WebSocket createWebSocket(String url, WebSocket.Listener listener) {
-    return new RoboWebSocket(platform, url, listener);
+    return new RoboWebSocket(platform, url, listener, ((RoboPlatform) platform).config.wsDraft);
   }
 
   @Override

--- a/robovm/src/playn/robovm/RoboPlatform.java
+++ b/robovm/src/playn/robovm/RoboPlatform.java
@@ -88,6 +88,9 @@ public class RoboPlatform extends AbstractPlatform {
     /** Dictates the name of the temporary file used by {@link RoboStorage}. Configure this if you
       * want to embed multiple games into your application. */
     public String storageFileName = "playn.db";
+   
+    /** Configure the web socket RFC draft number: 10, 17, 75 or 76 */
+    public int wsDraft = 10;
   }
 
   /** Enables games to respond to device orientation changes. */

--- a/robovm/src/playn/robovm/RoboWebSocket.java
+++ b/robovm/src/playn/robovm/RoboWebSocket.java
@@ -20,6 +20,11 @@ import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 
 import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.drafts.Draft_10;
+import org.java_websocket.drafts.Draft_17;
+import org.java_websocket.drafts.Draft_75;
+import org.java_websocket.drafts.Draft_76;
 import org.java_websocket.handshake.ServerHandshake;
 
 import playn.core.Net;
@@ -29,7 +34,7 @@ public class RoboWebSocket implements Net.WebSocket {
 
   private final WebSocketClient socket;
 
-  public RoboWebSocket(final Platform platform, String uri, final Listener listener) {
+  public RoboWebSocket(final Platform platform, String uri, final Listener listener, int draft) {
     URI juri = null;
     try {
       juri = new URI(uri);
@@ -37,7 +42,7 @@ public class RoboWebSocket implements Net.WebSocket {
       throw new RuntimeException(e);
     }
 
-    socket = new WebSocketClient(juri) {
+    socket = new WebSocketClient(juri, useDraft(draft)) {
       @Override
       public void onMessage(final ByteBuffer buffer) {
         platform.invokeLater(new Runnable() {
@@ -84,6 +89,18 @@ public class RoboWebSocket implements Net.WebSocket {
       }
     };
     socket.connect();
+  }
+  
+  private Draft useDraft(int draft){
+    switch (draft) {
+      case 17:
+        return new Draft_17();
+      case 75:
+        return new Draft_75();
+      case 76:
+        return new Draft_76();
+    }
+    return new Draft_10();
   }
 
   @Override


### PR DESCRIPTION
We have to configure the web socket draft number in order to work with servers supporting draft 17 at default. Unlike other backends, the HTML platform binds its support with browser so that the configuration is not applicable. 