### PR TITLE
Flushing PrintStream before calling toByteArray on the underlying ByteArrayOutputStream

### DIFF
--- a/core/tests/playn/core/json/InternalJsonWriterTest.java
+++ b/core/tests/playn/core/json/InternalJsonWriterTest.java
@@ -99,8 +99,10 @@ public class InternalJsonWriterTest {
   @Test
   public void testWriteToSystemOutLikeStream() {
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    PrintStream ps = new PrintStream(bytes);
     new JsonAppendableWriter(
-      new PrintStream(bytes)).object().value("a", 1).value("b", 2).end().done();
+      ps).object().value("a", 1).value("b", 2).end().done();
+    ps.flush();
     assertEquals("{\"a\":1,\"b\":2}", new String(bytes.toByteArray(), Charset.forName("UTF-8")));
   }
 


### PR DESCRIPTION
When a PrintStream instance wraps an underlying ByteArrayOutputStream instance,
it is recommended to flush or close the PrintStream before invoking the underlying instances's toByteArray(). Also, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a flush method before calling toByteArray().